### PR TITLE
Move travis environment into a script 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,22 @@ services:
 
 env:
   matrix:
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" CMAKE_BUILD_TYPE=Debug
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" CMAKE_BUILD_TYPE=Debug
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E ." CMAKE_BUILD_TYPE=Debug   WERROR=yes
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release DOCKERHUB=yes
-    - DISTRO=fedora_gmx2016 TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=fedora_gmx2016_d TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=fedora_gmx2018 TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=fedora_gmx2018_d TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=fedora_gmx9999 TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=fedora_gmx9999_d TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - DISTRO=ubuntu TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" CMAKE_BUILD_TYPE=Release
-    - TESTING=OFF CMAKE_BUILD_TYPE=Release WERROR=yes
-#useless for votca/votca, but for coverage of individual modules
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" CMAKE_BUILD_TYPE=None COVERAGE=yes
-    - TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" CMAKE_BUILD_TYPE=None COVERAGE=yes
-    - TESTING=OFF CMAKE_BUILD_TYPE=Release DOXYGEN=yes
-    - TESTING=OFF CMAKE_BUILD_TYPE=Release MINIMAL=yes
+    - ENV=1
+    - ENV=2
+    - ENV=3
+    - ENV=4
+    - ENV=5
+    - ENV=6
+    - ENV=7
+    - ENV=8
+    - ENV=9
+    - ENV=10
+    - ENV=11
+    - ENV=12
+    - ENV=13
+    - ENV=14
+    - ENV=15
+    - ENV=16
 
 matrix:
   exclude:
@@ -38,7 +37,7 @@ matrix:
   - compiler: clang #no new info when using clang
     env: TESTING=OFF CMAKE_BUILD_TYPE=Release DOXYGEN=yes 
 
-script:
+before_script:
  - git checkout -b current_commit
  - cd ../../
  - if [[ ${TRAVIS_REPO_SLUG} = */votca ]]; then
@@ -58,10 +57,16 @@ script:
      cp -vr ${HOME}/docker/votca/docker/* ${HOME}/docker;
      if [[ -d ${TRAVIS_REPO_SLUG}/docker ]]; then cp -vr ${TRAVIS_REPO_SLUG}/docker/* ${HOME}/docker; fi;
    fi
+ - source ${HOME}/docker/set_env.sh
  - cp -r $HOME/.ccache ${HOME}/docker/ccache
  - sed -i "1s/latest/${DISTRO:-latest}/" ${HOME}/docker/Dockerfile
- - travis_retry timeout 540 docker pull $(sed -n '1s/from //p' ${HOME}/docker/Dockerfile)
- - travis_retry docker build  --build-arg TESTOPTS="${TESTOPTS}" --build-arg COVERAGE=${COVERAGE}
+ - if [[ ! ${SKIP} ]]; then 
+     travis_retry timeout 540 docker pull $(sed -n '1s/from //p' ${HOME}/docker/Dockerfile);
+   fi
+
+script:
+ - if [[ ! ${SKIP} ]]; then
+     travis_retry docker build  --build-arg TESTOPTS="${TESTOPTS}" --build-arg COVERAGE=${COVERAGE}
                  --build-arg CC=${CC} --build-arg CXX=${CXX} --build-arg CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                  --build-arg CXXFLAGS="-Wall ${WERROR:+-Werror}"
                  --build-arg TESTING=${TESTING} --build-arg DOXYGEN=${DOXYGEN} --build-arg MINIMAL=${MINIMAL}
@@ -72,18 +77,19 @@ script:
                  --build-arg TRAVIS_COMMIT=${TRAVIS_COMMIT}
                  ${TRAVIS_TAG:+-t votca/votca:${TRAVIS_TAG}}
                  -t votca/votca:latest -t votca/votca:${TRAVIS_BRANCH} ${HOME}/docker/ &&
-   rm -rf $HOME/.ccache &&
-   CON=$(docker run -d votca/votca:${TRAVIS_BRANCH} /bin/bash) &&
-   docker cp ${CON}:/home/votca/.ccache ${HOME}/
+     rm -rf $HOME/.ccache &&
+     CON=$(docker run -d votca/votca:${TRAVIS_BRANCH} /bin/bash) &&
+     docker cp ${CON}:/home/votca/.ccache ${HOME}/;
+   fi
 
 after_success:
-  - shopt -s extglob && [[ ${TRAVIS_BRANCH} = @(master|stable|v1.*) && ${CC} = *gcc* && ${DOCKERHUB} = yes ]] && DEPLOY=yes
+  - shopt -s extglob && [[ ${TRAVIS_BRANCH} = @(master|stable|v1.*) && ${CC} = *gcc* && ${DOCKERHUB} = yes && ! ${SKIP} ]] && DEPLOY=yes
   - if [[ ${TRAVIS_BRANCH} = master ]]; then DOCKER_TAG=latest; else DOCKER_TAG="${TRAVIS_BRANCH}"; fi
   - if [[ ${DOCKER_USERNAME} && ${DOCKER_PASSWORD} && ${TRAVIS_PULL_REQUEST} == false && ${DEPLOY} ]]; then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
         docker push "${TRAVIS_REPO_SLUG}:${DOCKER_TAG}";
     fi
-  - if [[ ${DOXYGEN} = yes ]]; then
+  - if [[ ${DOXYGEN} = yes && ! ${SKIP} ]]; then
       git clone --depth=1 https://github.com/votca/doxygen.git "$HOME/devdoc";
       cd $HOME/devdoc;
       rm -f *;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,8 @@ env:
     - ENV=14
     - ENV=15
     - ENV=16
-
-matrix:
-  exclude:
-  - compiler: clang #taking too long
-    env: TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" CMAKE_BUILD_TYPE=None COVERAGE=yes
-  - compiler: clang #taking too long
-    env: TESTING=ON TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" CMAKE_BUILD_TYPE=None COVERAGE=yes
-  - compiler: clang #no new info when using clang
-    env: TESTING=OFF CMAKE_BUILD_TYPE=Release DOXYGEN=yes 
+    - ENV=17
+    - ENV=18
 
 before_script:
  - git checkout -b current_commit

--- a/docker/set_env.sh
+++ b/docker/set_env.sh
@@ -5,6 +5,7 @@ die () {
   exit 1
 }
 
+set -x
 if [[ $ENV -eq 1 ]]; then 
   export TESTING=ON 
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" 
@@ -84,6 +85,11 @@ elif [[ $ENV -eq 16 ]]; then
   export TESTING=OFF 
   export CMAKE_BUILD_TYPE=Release 
   export MINIMAL=yes
+elif [[ $ENV -eq 17 ]]; then 
+  export SKIP=yes
+elif [[ $ENV -eq 18 ]]; then 
+  export SKIP=yes
 else
   die "Unknown enviorment"
 fi
+set +x

--- a/docker/set_env.sh
+++ b/docker/set_env.sh
@@ -34,42 +34,42 @@ elif [[ $ENV -eq 5 ]]; then
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 6 ]]; then
   # Release build with gromacs-2016 (double)
   export DISTRO=fedora_gmx2016_d
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 7 ]]; then
   # Release build with gromacs-2018
   export DISTRO=fedora_gmx2018
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 8 ]]; then
   # Release build with gromacs-2018 (double)
   export DISTRO=fedora_gmx2018_d
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 9 ]]; then
   # Release build with gromacs master
   export DISTRO=fedora_gmx9999
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 10 ]]; then
   # Release build with gromacs master (double)
   export DISTRO=fedora_gmx9999_d
   export TESTING=ON
   export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # only csg uses gromacs
 elif [[ $ENV -eq 11 ]]; then
   # Release build on Ubuntu
   export DISTRO=ubuntu

--- a/docker/set_env.sh
+++ b/docker/set_env.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -xe
+
+die () {
+  echo "$*" >&2
+  exit 1
+}
+
+if [[ $ENV -eq 1 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" 
+  export CMAKE_BUILD_TYPE=Debug
+elif [[ $ENV -eq 2 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" 
+  export CMAKE_BUILD_TYPE=Debug
+elif [[ $ENV -eq 3 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E ." 
+  export CMAKE_BUILD_TYPE=Debug   
+  export WERROR=yes
+elif [[ $ENV -eq 4 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release 
+  export DOCKERHUB=yes
+elif [[ $ENV -eq 5 ]]; then 
+  export DISTRO=fedora_gmx2016 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 6 ]]; then 
+  export DISTRO=fedora_gmx2016_d 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 7 ]]; then 
+  export DISTRO=fedora_gmx2018 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 8 ]]; then 
+  export DISTRO=fedora_gmx2018_d 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 9 ]]; then 
+  export DISTRO=fedora_gmx9999 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 10 ]]; then 
+  export DISTRO=fedora_gmx9999_d 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 11 ]]; then 
+  export DISTRO=ubuntu 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  export CMAKE_BUILD_TYPE=Release
+elif [[ $ENV -eq 12 ]]; then 
+  export TESTING=OFF 
+  export CMAKE_BUILD_TYPE=Release 
+  export WERROR=yes
+elif [[ $ENV -eq 13 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" 
+  export CMAKE_BUILD_TYPE=None 
+#useless for votca/votca, but for coverage of individual modules
+  export COVERAGE=yes
+  [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
+elif [[ $ENV -eq 14 ]]; then 
+  export TESTING=ON 
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" 
+  export CMAKE_BUILD_TYPE=None 
+  export COVERAGE=yes
+  [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
+elif [[ $ENV -eq 15 ]]; then 
+  export TESTING=OFF 
+  export CMAKE_BUILD_TYPE=Release 
+  export DOXYGEN=yes
+  [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
+elif [[ $ENV -eq 16 ]]; then 
+  export TESTING=OFF 
+  export CMAKE_BUILD_TYPE=Release 
+  export MINIMAL=yes
+else
+  die "Unknown enviorment"
+fi

--- a/docker/set_env.sh
+++ b/docker/set_env.sh
@@ -6,90 +6,118 @@ die () {
 }
 
 set -x
-if [[ $ENV -eq 1 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" 
+if [[ $ENV -eq 1 ]]; then
+  # Debug build with half the tests (due to timing constraints)
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)"
   export CMAKE_BUILD_TYPE=Debug
-elif [[ $ENV -eq 2 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" 
+elif [[ $ENV -eq 2 ]]; then
+  # Debug build with second half of the tests
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re"
   export CMAKE_BUILD_TYPE=Debug
-elif [[ $ENV -eq 3 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E ." 
-  export CMAKE_BUILD_TYPE=Debug   
+elif [[ $ENV -eq 3 ]]; then
+  # Debug build with -Werror, build tests as well, but exclude all tests
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E ."
+  export CMAKE_BUILD_TYPE=Debug
   export WERROR=yes
-elif [[ $ENV -eq 4 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
-  export CMAKE_BUILD_TYPE=Release 
+elif [[ $ENV -eq 4 ]]; then
+  # Release build, which gets push to dockerhun
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
+  export CMAKE_BUILD_TYPE=Release
   export DOCKERHUB=yes
-elif [[ $ENV -eq 5 ]]; then 
-  export DISTRO=fedora_gmx2016 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+elif [[ $ENV -eq 5 ]]; then
+  # Release build with gromacs-2016
+  export DISTRO=fedora_gmx2016
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 6 ]]; then 
-  export DISTRO=fedora_gmx2016_d 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 6 ]]; then
+  # Release build with gromacs-2016 (double)
+  export DISTRO=fedora_gmx2016_d
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 7 ]]; then 
-  export DISTRO=fedora_gmx2018 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 7 ]]; then
+  # Release build with gromacs-2018
+  export DISTRO=fedora_gmx2018
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 8 ]]; then 
-  export DISTRO=fedora_gmx2018_d 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 8 ]]; then
+  # Release build with gromacs-2018 (double)
+  export DISTRO=fedora_gmx2018_d
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 9 ]]; then 
-  export DISTRO=fedora_gmx9999 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 9 ]]; then
+  # Release build with gromacs master
+  export DISTRO=fedora_gmx9999
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 10 ]]; then 
-  export DISTRO=fedora_gmx9999_d 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 10 ]]; then
+  # Release build with gromacs master (double)
+  export DISTRO=fedora_gmx9999_d
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 11 ]]; then 
-  export DISTRO=ubuntu 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)" 
+  [[ ${TRAVIS_REPO_SLUG} = */csg ]] || export SKIP=yes # only csg uses gromacs
+elif [[ $ENV -eq 11 ]]; then
+  # Release build on Ubuntu
+  export DISTRO=ubuntu
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\)"
   export CMAKE_BUILD_TYPE=Release
-elif [[ $ENV -eq 12 ]]; then 
-  export TESTING=OFF 
-  export CMAKE_BUILD_TYPE=Release 
+elif [[ $ENV -eq 12 ]]; then
+  # Release build with -Werror, build tests as well, but exclude all tests
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E ."
+  export CMAKE_BUILD_TYPE=Release
   export WERROR=yes
-elif [[ $ENV -eq 13 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)" 
-  export CMAKE_BUILD_TYPE=None 
-#useless for votca/votca, but for coverage of individual modules
+elif [[ $ENV -eq 13 ]]; then
+  # Build with no cmake_build_type and coverage on, first half of the tests
+  # superbuild has no code, so no coverage, but test None build type
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -E \(_imc\|spce_cma_simple\|_re\)"
+  export CMAKE_BUILD_TYPE=None
   export COVERAGE=yes
   [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
-elif [[ $ENV -eq 14 ]]; then 
-  export TESTING=ON 
-  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re" 
-  export CMAKE_BUILD_TYPE=None 
+elif [[ $ENV -eq 14 ]]; then
+  # Build with no cmake_build_type and coverage on, second half of the tests
+  # superbuild has no code, so no coverage, but test None build type
+  export TESTING=ON
+  export TESTOPTS="-L ${TRAVIS_REPO_SLUG#*/} -R _re"
+  export CMAKE_BUILD_TYPE=None
   export COVERAGE=yes
   [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
-elif [[ $ENV -eq 15 ]]; then 
-  export TESTING=OFF 
-  export CMAKE_BUILD_TYPE=Release 
+elif [[ $ENV -eq 15 ]]; then
+  # Build with doxygen
+  export TESTING=OFF
+  export CMAKE_BUILD_TYPE=Release
   export DOXYGEN=yes
   [[ $CC = clang ]] && export SKIP=yes # no new info when using clang
-elif [[ $ENV -eq 16 ]]; then 
-  export TESTING=OFF 
-  export CMAKE_BUILD_TYPE=Release 
+  [[ ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes #only votca/votca actually deploys doxygen - re-enable if we check for doxygen warnings
+elif [[ $ENV -eq 16 ]]; then
+  # minimal build without external libs (tools & csg only)
+  export TESTING=OFF
+  export CMAKE_BUILD_TYPE=Release
   export MINIMAL=yes
-elif [[ $ENV -eq 17 ]]; then 
+  [[ ${TRAVIS_REPO_SLUG} = */csg || ${TRAVIS_REPO_SLUG} = */tools || ${TRAVIS_REPO_SLUG} = */votca ]] || export SKIP=yes # minimal build is only for tools, csg and superbuild
+elif [[ $ENV -eq 17 ]]; then
+  # for future use
   export SKIP=yes
-elif [[ $ENV -eq 18 ]]; then 
+elif [[ $ENV -eq 18 ]]; then
+  # for future use
   export SKIP=yes
 else
-  die "Unknown enviorment"
+  die "Unknown environment"
 fi
 set +x


### PR DESCRIPTION
This will allow us to modify the environment in votca/votca without having to copy the `.travis.yml` file over to all the repos. (Except if we need more environments, 18 currently.)

Plus we could trigger builds more fine-grained, e.g. only build different gromacs versions for csg. 