### PR TITLE
fix docker deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
 
 after_success:
   - if [[ ${TRAVIS_REPO_SLUG} != votca/votca || ${SKIP} ]]; then travis_terminate 0; fi
-  - shopt -s extglob && [[ ${TRAVIS_BRANCH} = @(development|master|stable|v1.*) && ${TRAVIS_BUILD_STAGE_NAME} = "Deploy" ]] && DEPLOY=yes
+  - shopt -s extglob && [[ ${TRAVIS_BRANCH} = @(development|master|stable|v1.*) && ${TRAVIS_BUILD_STAGE_NAME} = [Dd]eploy ]] && DEPLOY=yes
   - if [[ ${TRAVIS_BRANCH} = master ]]; then DOCKER_TAG=latest; else DOCKER_TAG="${TRAVIS_BRANCH}"; fi
   - if [[ ${DOCKER_USERNAME} && ${DOCKER_PASSWORD} && ${TRAVIS_PULL_REQUEST} == false && ${DEPLOY} ]]; then
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";


### PR DESCRIPTION
It seems TRAVIS_BUILD_STAGE_NAME doesn't get capitalized anymore,
even though the documentation says so.

Also reported here: https://github.com/mlflow/mlflow/issues/2631