### PR TITLE
Revert "Merge pull request #274 from votca/cmake_rm_find_clang_format"

### DIFF
--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -1,0 +1,64 @@
+# Find clang-format
+#
+# CLANG_FORMAT_EXECUTABLE   - Path to clang-format executable
+# CLANG_FORMAT_FOUND        - True if the clang-format executable was found.
+# CLANG_FORMAT_VERSION      - The version of clang-format found
+#
+# Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+find_program(CLANG_FORMAT_EXECUTABLE
+             NAMES clang-format
+                   clang-format-8
+                   clang-format-7
+                   clang-format-6.0
+                   clang-format-5.0
+                   clang-format-4.0
+                   clang-format-3.9
+                   clang-format-3.8
+                   clang-format-3.7
+                   clang-format-3.6
+                   clang-format-3.5
+                   clang-format-3.4
+                   clang-format-3.3
+             DOC "clang-format executable")
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+# Extract version from command "clang-format -version"
+if(CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(clang_format_version MATCHES "^clang-format version .*")
+    # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
+    # (tags/RELEASE_391/rc2)"
+    string(REGEX
+           REPLACE "clang-format version ([.0-9]+).*"
+                   "\\1"
+                   CLANG_FORMAT_VERSION
+                   "${clang_format_version}")
+    # CLANG_FORMAT_VERSION sample: "3.9.1"
+  else()
+    set(CLANG_FORMAT_VERSION 0.0)
+  endif()
+else()
+  set(CLANG_FORMAT_VERSION 0.0)
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CLANG_FORMAT_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CLANG_FORMAT REQUIRED_VARS CLANG_FORMAT_EXECUTABLE VERSION_VAR CLANG_FORMAT_VERSION)

--- a/share/format/CMakeLists.txt
+++ b/share/format/CMakeLists.txt
@@ -1,10 +1,5 @@
-find_package(LLVM QUIET)
-set_package_properties(LLVM PROPERTIES TYPE OPTIONAL PURPOSE "Needed for automatic code formatting with clang-format")
-if(LLVM_FOUND)
-  find_package(Clang QUIET)
-  set_package_properties(Clang PROPERTIES TYPE OPTIONAL PURPOSE "Needed for automatic code formatting with clang-format")
-endif()
-if(TARGET clang-format)
+find_package(CLANG_FORMAT 7.0.1)
+if(CLANG_FORMAT_FOUND)
   set(FORMAT_SOURCES)
   foreach(DIR ${ENABLED_VOTCA_PACKAGES})
     set(ABS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../${DIR})
@@ -12,6 +7,6 @@ if(TARGET clang-format)
     list(APPEND FORMAT_SOURCES ${${DIR}_SOURCES})
   endforeach()
   add_custom_target(format
-    COMMAND $<TARGET_FILE:clang-format> -i -style=file ${FORMAT_SOURCES}
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
     DEPENDS ${FORMAT_SOURCES})
 endif()


### PR DESCRIPTION
This reverts commit a10f9cae7941d90caa76b6c08e997b9a32edad22, partly reversing
changes made to 447b535fb0aee85d5a424281c12bb90e27982a84.

This too broken on Ubuntu triggering a fatal error (see https://groups.google.com/d/msg/votca/a2D4zoxhx6o/hGMhW9J5AwAJ), so reverting to the old scheme.