### PR TITLE
used nbsphinx to generate documentation

### DIFF
--- a/share/doc/conf.py.in
+++ b/share/doc/conf.py.in
@@ -31,6 +31,7 @@ html_context = {
 
 
 extensions = [
+    'nbsphinx', # Generate sphinx documentation directly from the jupyter notebooks
     'recommonmark', # Parse markdown
     'sphinx.ext.mathjax', # Write equations
     'sphinx.ext.githubpages' # Create content to publish in githubpages


### PR DESCRIPTION
## Changes
Used the [Python nbsphinx extension](https://nbsphinx.readthedocs.io/en/0.7.0/) to directly convert the Jupyter notebooks into Sphinx documentation.