### PR TITLE
allow errors in  nbsphinx

### DIFF
--- a/share/doc/conf.py.in
+++ b/share/doc/conf.py.in
@@ -19,6 +19,7 @@ html_theme_options= { 'logo_only' : True }
 
 #html_theme = 'alabaster'
 master_doc = 'index'
+nbsphinx_allow_errors = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
## Issue
In some linux distribution there is not available a suitable [nbsphinx converter](https://nbsphinx.readthedocs.io/en/0.7.1/) causing an error when generating the documentation.

## solution
*nbsphinx* error can be ignored with the `nbsphinx_allow_errors` flag