### PR TITLE
updated clang-format and require exact version

### DIFF
--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -21,6 +21,8 @@
 
 find_program(CLANG_FORMAT_EXECUTABLE
              NAMES clang-format
+                   clang-format-10
+                   clang-format-9
                    clang-format-8
                    clang-format-7
                    clang-format-6.0

--- a/share/format/CMakeLists.txt
+++ b/share/format/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(CLANG_FORMAT 7.0.1)
+find_package(CLANG_FORMAT 10)
 if(CLANG_FORMAT_FOUND)
   set(FORMAT_SOURCES)
   foreach(DIR ${ENABLED_VOTCA_PACKAGES})


### PR DESCRIPTION
Updated the findClangFormat so it finds the newest version first.

Also require version 10 exactly now. 