### PR TITLE
GHA: drop gentoo

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -104,9 +104,6 @@ jobs:
             cmake_build_type: Release
             continue-on-error: true
             no_regression_testing: true
-          - distro: 'gentoo:latest'
-            toolchain: gnu
-            cmake_build_type: Release
     runs-on: ubuntu-latest
     container: ghcr.io/votca/buildenv/${{ matrix.distro }}
     steps:


### PR DESCRIPTION
Gentoo buildenv builds are taking too long.