### PR TITLE
updated FindClang

### DIFF
--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -49,7 +49,7 @@ if(CLANG_FORMAT_EXECUTABLE)
     # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
     # (tags/RELEASE_391/rc2)"
     string(REGEX
-           REPLACE "^[^ ]*[ ]*clang-format version ([.0-9]+).*"
+           REPLACE "^.*clang-format version ([.0-9]+).*"
                    "\\1"
                    CLANG_FORMAT_VERSION
                    "${clang_format_version}")

--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -20,7 +20,8 @@
 #
 
 find_program(CLANG_FORMAT_EXECUTABLE
-             NAMES clang-format
+             NAMES clang-format-11
+                   clang-format
                    clang-format-10
                    clang-format-9
                    clang-format-8

--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -20,8 +20,8 @@
 #
 
 find_program(CLANG_FORMAT_EXECUTABLE
-             NAMES clang-format-11
-                   clang-format
+             NAMES clang-format
+                   clang-format-11
                    clang-format-10
                    clang-format-9
                    clang-format-8

--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -45,7 +45,7 @@ if(CLANG_FORMAT_EXECUTABLE)
                   OUTPUT_VARIABLE clang_format_version
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  if(clang_format_version MATCHES "^[^ ]*[ ]*clang-format version .*")
+  if(clang_format_version MATCHES "^.*clang-format version .*")
     # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
     # (tags/RELEASE_391/rc2)"
     string(REGEX

--- a/CMakeModules/FindCLANG_FORMAT.cmake
+++ b/CMakeModules/FindCLANG_FORMAT.cmake
@@ -45,11 +45,11 @@ if(CLANG_FORMAT_EXECUTABLE)
                   OUTPUT_VARIABLE clang_format_version
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  if(clang_format_version MATCHES "^clang-format version .*")
+  if(clang_format_version MATCHES "^[^ ]*[ ]*clang-format version .*")
     # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
     # (tags/RELEASE_391/rc2)"
     string(REGEX
-           REPLACE "clang-format version ([.0-9]+).*"
+           REPLACE "^[^ ]*[ ]*clang-format version ([.0-9]+).*"
                    "\\1"
                    CLANG_FORMAT_VERSION
                    "${clang_format_version}")


### PR DESCRIPTION
updated so it finds clang-format-11 first and then tries for the general clang-format.

Also updated regex because ubuntu likes to put a "ubuntu" in front which breaks the regex otherwise. 