### PR TITLE
Fix deprecated bind2nd

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,6 +123,7 @@ Version 2022-dev
 -  check for gmx-2019 in csg-tutorials (#875)
 -  added the full basissets to the orb checkpoint file (#863)
 -  return default for empty strings in option file (#873)
+-  replaced removed std::bind2nd by lambda (#881)
 
 Version 2021.2 and earlier
 ==========================

--- a/tools/src/libtools/histogram.cc
+++ b/tools/src/libtools/histogram.cc
@@ -17,9 +17,9 @@
 
 // Standard includes
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <numeric>
-#include <functional>
 
 // Local VOTCA includes
 #include "votca/tools/histogram.h"
@@ -116,7 +116,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
 void Histogram::Normalize() {
   double norm = 1. / (interval_ * accumulate(pdf_.begin(), pdf_.end(), 0.0));
   std::transform(pdf_.begin(), pdf_.end(), pdf_.begin(),
-                [norm](double a){return a * norm;});
+                 [norm](double a) { return a * norm; });
 }
 
 }  // namespace tools

--- a/tools/src/libtools/histogram.cc
+++ b/tools/src/libtools/histogram.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <limits>
 #include <numeric>
+#include <functional>
 
 // Local VOTCA includes
 #include "votca/tools/histogram.h"
@@ -115,7 +116,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
 void Histogram::Normalize() {
   double norm = 1. / (interval_ * accumulate(pdf_.begin(), pdf_.end(), 0.0));
   std::transform(pdf_.begin(), pdf_.end(), pdf_.begin(),
-                 std::bind2nd(std::multiplies<double>(), norm));
+                 std::bind(std::multiplies<double>(),std::placeholders::_2, norm));
 }
 
 }  // namespace tools

--- a/tools/src/libtools/histogram.cc
+++ b/tools/src/libtools/histogram.cc
@@ -116,7 +116,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
 void Histogram::Normalize() {
   double norm = 1. / (interval_ * accumulate(pdf_.begin(), pdf_.end(), 0.0));
   std::transform(pdf_.begin(), pdf_.end(), pdf_.begin(),
-                 std::bind(std::multiplies<double>(),std::placeholders::_2, norm));
+                [norm](double a){return a * norm;});
 }
 
 }  // namespace tools

--- a/tools/src/libtools/rangeparser.cc
+++ b/tools/src/libtools/rangeparser.cc
@@ -32,7 +32,7 @@ RangeParser::RangeParser() = default;
 void RangeParser::Parse(std::string str) {
   // remove all spaces in string
   std::string::iterator it = std::remove_if(
-      str.begin(), str.end(), std::bind(std::equal_to<char>(), std::placeholders::_2, ,' '));
+      str.begin(), str.end(), [](char a){ return a==' ';});
   str = std::string(str.begin(), it);
 
   Tokenizer tok(str, ",");

--- a/tools/src/libtools/rangeparser.cc
+++ b/tools/src/libtools/rangeparser.cc
@@ -32,7 +32,7 @@ RangeParser::RangeParser() = default;
 void RangeParser::Parse(std::string str) {
   // remove all spaces in string
   std::string::iterator it = std::remove_if(
-      str.begin(), str.end(), std::bind2nd(std::equal_to<char>(), ' '));
+      str.begin(), str.end(), std::bind(std::equal_to<char>(), std::placeholders::_2, ,' '));
   str = std::string(str.begin(), it);
 
   Tokenizer tok(str, ",");

--- a/tools/src/libtools/rangeparser.cc
+++ b/tools/src/libtools/rangeparser.cc
@@ -31,8 +31,8 @@ RangeParser::RangeParser() = default;
 
 void RangeParser::Parse(std::string str) {
   // remove all spaces in string
-  std::string::iterator it = std::remove_if(
-      str.begin(), str.end(), [](char a){ return a==' ';});
+  std::string::iterator it =
+      std::remove_if(str.begin(), str.end(), [](char a) { return a == ' '; });
   str = std::string(str.begin(), it);
 
   Tokenizer tok(str, ",");


### PR DESCRIPTION
Replaced the `std::bind2nd` with lambda expressions, since `bind2nd` is removed from C++17