### PR TITLE
Change error to warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -124,6 +124,7 @@ Version 2022-dev
 -  added the full basissets to the orb checkpoint file (#863)
 -  return default for empty strings in option file (#873)
 -  replaced removed std::bind2nd by lambda (#881)
+-  change error to warning in reading lammps bonds (#884)
 
 Version 2021.2 and earlier
 ==========================

--- a/csg/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/csg/src/libcsg/modules/io/lammpsdatareader.cc
@@ -573,11 +573,11 @@ void LAMMPSDataReader::ReadBonds_(Topology &top) {
       Index atom1Index = atomIdToIndex_[atom1Id];
       Index atom2Index = atomIdToIndex_[atom2Id];
       if (atomIdToMoleculeId_[atom1Index] != atomIdToMoleculeId_[atom2Index]) {
-        throw std::runtime_error(
-            "Lammps Atoms " + std::to_string(atom1Id + 1) + " and " +
+        cout <<
+            "WARNING: Lammps Atoms " + std::to_string(atom1Id + 1) + " and " +
             std::to_string(atom2Id + 1) + " belong to different molecules (" +
             std::to_string(atomIdToMoleculeId_[atom1Index] + 1) + ":" +
-            std::to_string(atomIdToMoleculeId_[atom2Index] + 1) + ")");
+            std::to_string(atomIdToMoleculeId_[atom2Index] + 1) + ")";
       }
 
       Interaction *ic = new IBond(atom1Index, atom2Index);

--- a/csg/src/libcsg/modules/io/lammpsdatareader.cc
+++ b/csg/src/libcsg/modules/io/lammpsdatareader.cc
@@ -573,11 +573,14 @@ void LAMMPSDataReader::ReadBonds_(Topology &top) {
       Index atom1Index = atomIdToIndex_[atom1Id];
       Index atom2Index = atomIdToIndex_[atom2Id];
       if (atomIdToMoleculeId_[atom1Index] != atomIdToMoleculeId_[atom2Index]) {
-        cout <<
-            "WARNING: Lammps Atoms " + std::to_string(atom1Id + 1) + " and " +
-            std::to_string(atom2Id + 1) + " belong to different molecules (" +
-            std::to_string(atomIdToMoleculeId_[atom1Index] + 1) + ":" +
-            std::to_string(atomIdToMoleculeId_[atom2Index] + 1) + ")";
+        std::cout << "WARNING: Lammps Atoms " + std::to_string(atom1Id + 1) +
+                         " and " + std::to_string(atom2Id + 1) +
+                         " belong to different molecules (" +
+                         std::to_string(atomIdToMoleculeId_[atom1Index] + 1) +
+                         ":" +
+                         std::to_string(atomIdToMoleculeId_[atom2Index] + 1) +
+                         ")"
+                  << std::endl;
       }
 
       Interaction *ic = new IBond(atom1Index, atom2Index);


### PR DESCRIPTION
In PR 703 of the CSG repo, a change was made where an error is thrown if you try to read a lammps file with bonds between molecules. (https://github.com/votca/csg/pull/703)

This change prevents us from loading a polymer in votca where the different monomers are labelled with a different molecule id. This is something we sometimes like to do in the XTP part. 

As a first suggestion I changed the `std::runtime_error` to a `std::cout`. In this way the user still gets notified of the bond between two different molecules, but the program won't terminate.