### PR TITLE
properly parse tasks_string with tokenizer 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -132,6 +132,7 @@ Version 2022-dev
 -  bump required cmake version to 3.13 to support -B option (#887, #893)
 -  changed hard coded file to option value in eqm.cc (#900)
 -  inject march=native by default and add cmake option for valgrind tests (#896)
+-  Refactor parsing of the tasks_string (#902)
 
 
 Version 2021.2 and earlier

--- a/xtp/src/libxtp/gwbse/gwbseengine.cc
+++ b/xtp/src/libxtp/gwbse/gwbseengine.cc
@@ -50,12 +50,11 @@ void GWBSEEngine::Initialize(tools::Property& options,
   std::vector<std::string> tasks = tokenizedTasks.ToVector();
 
   // Check which tasks exist and set them to true
-  do_guess_ =  std::find(tasks.begin(), tasks.end(), "guess") != tasks.end();
+  do_guess_ = std::find(tasks.begin(), tasks.end(), "guess") != tasks.end();
   do_dft_input_ = std::find(tasks.begin(), tasks.end(), "input") != tasks.end();
   do_dft_run_ = std::find(tasks.begin(), tasks.end(), "dft") != tasks.end();
   do_dft_parse_ = std::find(tasks.begin(), tasks.end(), "parse") != tasks.end();
   do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gwbse") != tasks.end();
-
 
   // XML option file for GWBSE
   if (do_gwbse_) {

--- a/xtp/src/libxtp/gwbse/gwbseengine.cc
+++ b/xtp/src/libxtp/gwbse/gwbseengine.cc
@@ -45,21 +45,17 @@ void GWBSEEngine::Initialize(tools::Property& options,
 
   std::string tasks_string = options.get(".tasks").as<std::string>();
 
-  if (tasks_string.find("guess") != std::string::npos) {
-    do_guess_ = true;
-  }
-  if (tasks_string.find("input") != std::string::npos) {
-    do_dft_input_ = true;
-  }
-  if (tasks_string.find("dft") != std::string::npos) {
-    do_dft_run_ = true;
-  }
-  if (tasks_string.find("parse") != std::string::npos) {
-    do_dft_parse_ = true;
-  }
-  if (tasks_string.find("gwbse") != std::string::npos) {
-    do_gwbse_ = true;
-  }
+  // We split either on a space or a comma
+  tools::Tokenizer tokenizedTasks(tasks_string, " ,");
+  std::vector<std::string> tasks = tokenizedTasks.ToVector();
+
+  // Check which tasks exist and set them to true
+  do_guess_ =  std::find(tasks.begin(), tasks.end(), "guess") != tasks.end();
+  do_dft_input_ = std::find(tasks.begin(), tasks.end(), "input") != tasks.end();
+  do_dft_run_ = std::find(tasks.begin(), tasks.end(), "dft") != tasks.end();
+  do_dft_parse_ = std::find(tasks.begin(), tasks.end(), "parse") != tasks.end();
+  do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gwbse") != tasks.end();
+
 
   // XML option file for GWBSE
   if (do_gwbse_) {

--- a/xtp/src/libxtp/jobcalculators/eqm.cc
+++ b/xtp/src/libxtp/jobcalculators/eqm.cc
@@ -42,21 +42,15 @@ void EQM::ParseSpecificOptions(const tools::Property& options) {
   // job tasks
   std::string tasks_string_ = options.get(".tasks").as<std::string>();
 
-  if (tasks_string_.find("input") != std::string::npos) {
-    do_dft_input_ = true;
-  }
-  if (tasks_string_.find("dft") != std::string::npos) {
-    do_dft_run_ = true;
-  }
-  if (tasks_string_.find("parse") != std::string::npos) {
-    do_dft_parse_ = true;
-  }
-  if (tasks_string_.find("gwbse") != std::string::npos) {
-    do_gwbse_ = true;
-  }
-  if (tasks_string_.find("esp") != std::string::npos) {
-    do_esp_ = true;
-  }
+  // We split either on a space or a comma
+  tools::Tokenizer tokenizedTasks(tasks_string, " ,");
+  std::vector<std::string> tasks = tokenizedTasks.ToVector();
+
+  do_dft_input_ = std::find(tasks.begin(), tasks.end(), "input") != tasks.end();
+  do_dft_run_ = std::find(tasks.begin(), tasks.end(), "dft") != tasks.end();
+  do_dft_parse_ = std::find(tasks.begin(), tasks.end(), "parse") != tasks.end();
+  do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gwbse") != tasks.end();
+  do_esp_ = std::find(tasks.begin(), tasks.end(), "esp") != tasks.end();
 
   // set the basis sets and functional for DFT and GWBSE
   gwbse_options_ = options.get("gwbse");

--- a/xtp/src/libxtp/jobcalculators/eqm.cc
+++ b/xtp/src/libxtp/jobcalculators/eqm.cc
@@ -40,7 +40,7 @@ void EQM::ParseSpecificOptions(const tools::Property& options) {
   QMPackageFactory::RegisterAll();
 
   // job tasks
-  std::string tasks_string_ = options.get(".tasks").as<std::string>();
+  std::string tasks_string = options.get(".tasks").as<std::string>();
 
   // We split either on a space or a comma
   tools::Tokenizer tokenizedTasks(tasks_string, " ,");

--- a/xtp/src/libxtp/jobcalculators/iqm.cc
+++ b/xtp/src/libxtp/jobcalculators/iqm.cc
@@ -58,7 +58,7 @@ void IQM::ParseSpecificOptions(const tools::Property& options) {
   do_dft_parse_ = std::find(tasks.begin(), tasks.end(), "parse") != tasks.end();
   do_dftcoupling_ =
       std::find(tasks.begin(), tasks.end(), "dftcoupling") != tasks.end();
-  do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gw") != tasks.end();
+  do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gwbse") != tasks.end();
   do_bsecoupling_ =
       std::find(tasks.begin(), tasks.end(), "bsecoupling") != tasks.end();
 

--- a/xtp/src/libxtp/jobcalculators/iqm.cc
+++ b/xtp/src/libxtp/jobcalculators/iqm.cc
@@ -47,24 +47,20 @@ void IQM::ParseSpecificOptions(const tools::Property& options) {
 
   // job tasks
   std::string tasks_string = options.get(".tasks").as<std::string>();
-  if (tasks_string.find("input") != std::string::npos) {
-    do_dft_input_ = true;
-  }
-  if (tasks_string.find("dft") != std::string::npos) {
-    do_dft_run_ = true;
-  }
-  if (tasks_string.find("parse") != std::string::npos) {
-    do_dft_parse_ = true;
-  }
-  if (tasks_string.find("dftcoupling") != std::string::npos) {
-    do_dftcoupling_ = true;
-  }
-  if (tasks_string.find("gw") != std::string::npos) {
-    do_gwbse_ = true;
-  }
-  if (tasks_string.find("bsecoupling") != std::string::npos) {
-    do_bsecoupling_ = true;
-  }
+
+  // We split either on a space or a comma
+  tools::Tokenizer tokenizedTasks(tasks_string, " ,");
+  std::vector<std::string> tasks = tokenizedTasks.ToVector();
+
+  // Check which tasks exist and set them to true
+  do_dft_input_ = std::find(tasks.begin(), tasks.end(), "input") != tasks.end();
+  do_dft_run_ = std::find(tasks.begin(), tasks.end(), "dft") != tasks.end();
+  do_dft_parse_ = std::find(tasks.begin(), tasks.end(), "parse") != tasks.end();
+  do_dftcoupling_ =
+      std::find(tasks.begin(), tasks.end(), "dftcoupling") != tasks.end();
+  do_gwbse_ = std::find(tasks.begin(), tasks.end(), "gw") != tasks.end();
+  do_bsecoupling_ =
+      std::find(tasks.begin(), tasks.end(), "bsecoupling") != tasks.end();
 
   // storage options
   std::string store_string = options.get(".store").as<std::string>();


### PR DESCRIPTION
The tasks_string parsing is done with the tokenizer now instead of string searches in the iqm calculator.

This should also be updated in eqm and the gwbseengine.