### PR TITLE
Fix bug in basisset serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -144,6 +144,7 @@ Version 2022-rc.1 (released 26.11.21)
 -  Read number of alpha electrons from orca log, not from molden (#901)
 -  Refactor parsing of the tasks_string (#902)
 -  set correct filename for initial guess from monomer orbitals (#904)
+-  fix bug in basisset serialization that caused wrong Vxc values in GW (#910)
 
 
 Version 2021.2 and earlier

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,11 @@ For more detailed information about the changes see the history of the
 Version 2022-dev
 ================
 
--  fix iqm merge orbitals command  (#907)
-
 Version 2022-rc.2 (released XX.11.21)
 =====================================
+
+-  fix iqm merge orbitals command  (#907)
+-  fix bug in basisset serialization that caused wrong Vxc values in GW (#910)
 
 Version 2022-rc.1 (released 26.11.21)
 =====================================
@@ -144,8 +145,6 @@ Version 2022-rc.1 (released 26.11.21)
 -  Read number of alpha electrons from orca log, not from molden (#901)
 -  Refactor parsing of the tasks_string (#902)
 -  set correct filename for initial guess from monomer orbitals (#904)
--  fix bug in basisset serialization that caused wrong Vxc values in GW (#910)
-
 
 Version 2021.2 and earlier
 ==========================

--- a/xtp/src/libxtp/aobasis.cc
+++ b/xtp/src/libxtp/aobasis.cc
@@ -157,7 +157,6 @@ void AOBasis::WriteToCpt(CheckpointWriter& w) const {
       i++;
     }
   }
-
   table.write(dataVec);
 }
 
@@ -181,6 +180,9 @@ void AOBasis::ReadFromCpt(CheckpointReader& r) {
     }
 
     FillFuncperAtom();
+  }
+  for (auto& shell : aoshells_){
+    shell.CalcMinDecay();
   }
 }
 

--- a/xtp/src/libxtp/aobasis.cc
+++ b/xtp/src/libxtp/aobasis.cc
@@ -181,7 +181,7 @@ void AOBasis::ReadFromCpt(CheckpointReader& r) {
 
     FillFuncperAtom();
   }
-  for (auto& shell : aoshells_){
+  for (auto& shell : aoshells_) {
     shell.CalcMinDecay();
   }
 }

--- a/xtp/src/tests/test_hdf5.cc
+++ b/xtp/src/tests/test_hdf5.cc
@@ -169,13 +169,13 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
   bool basissets_equal = (ssWrite.str() == ssRead.str());
   BOOST_CHECK(basissets_equal);
 
-  if(!basissets_equal){
+  if (!basissets_equal) {
     std::cout << "Thing we wrote:" << std::endl;
     std::cout << ssWrite.str();
     std::cout << "Thing we read:" << std::endl;
     std::cout << ssRead.str();
   }
-  
+
   libint2::finalize();
 }
 

--- a/xtp/src/tests/test_hdf5.cc
+++ b/xtp/src/tests/test_hdf5.cc
@@ -79,38 +79,36 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
   Eigen::MatrixXd BSETripletCoefficientsTest = Eigen::MatrixXd::Random(33, 31);
 
   Index basisSetSize = 0;
-  {
-    // Write orbitals
-    Orbitals orbWrite;
-    orbWrite.setNumberOfOccupiedLevels(occupiedLevels);
-    orbWrite.setNumberOfAlphaElectrons(numElectrons);
-    orbWrite.MOs().eigenvalues() = moeTest;
-    orbWrite.MOs().eigenvectors() = mocTest;
 
-    orbWrite.QMAtoms() = atoms;
-    orbWrite.SetupDftBasis(std::string(XTP_TEST_DATA_FOLDER) +
-                           "/hdf5/3-21G.xml");
-    basisSetSize = orbWrite.getBasisSetSize();
+  // Write orbitals
+  Orbitals orbWrite;
+  orbWrite.setNumberOfOccupiedLevels(occupiedLevels);
+  orbWrite.setNumberOfAlphaElectrons(numElectrons);
+  orbWrite.MOs().eigenvalues() = moeTest;
+  orbWrite.MOs().eigenvectors() = mocTest;
 
-    orbWrite.setQMEnergy(qmEnergy);
-    orbWrite.setQMpackage(qmPackage);
-    orbWrite.setRPAindices(rpaMin, rpaMax);
-    // no need to write qpmin, qpmax
-    orbWrite.setBSEindices(bseVmin, bseCmax);
-    orbWrite.setScaHFX(scaHfx);
-    orbWrite.setTDAApprox(useTDA);
-    orbWrite.setECPName(someECP);
-    orbWrite.QPpertEnergies() = QPpertEnergiesTest;
-    orbWrite.QPdiag().eigenvalues() = QPdiagEnergiesTest;
-    orbWrite.QPdiag().eigenvectors() = QPdiagCoefficientsTest;
-    orbWrite.BSESinglets().eigenvalues() = BSESingletEnergiesTest;
-    orbWrite.BSESinglets().eigenvectors() = BSESingletCoefficientsTest;
-    orbWrite.BSESinglets().eigenvectors2() = BSESingletCoefficientsARTest;
-    orbWrite.BSETriplets().eigenvalues() = BSETripletEnergiesTest;
-    orbWrite.BSETriplets().eigenvectors() = BSETripletCoefficientsTest;
+  orbWrite.QMAtoms() = atoms;
+  orbWrite.SetupDftBasis(std::string(XTP_TEST_DATA_FOLDER) + "/hdf5/3-21G.xml");
+  basisSetSize = orbWrite.getBasisSetSize();
 
-    orbWrite.WriteToCpt("xtp_testing.hdf5");
-  }
+  orbWrite.setQMEnergy(qmEnergy);
+  orbWrite.setQMpackage(qmPackage);
+  orbWrite.setRPAindices(rpaMin, rpaMax);
+  // no need to write qpmin, qpmax
+  orbWrite.setBSEindices(bseVmin, bseCmax);
+  orbWrite.setScaHFX(scaHfx);
+  orbWrite.setTDAApprox(useTDA);
+  orbWrite.setECPName(someECP);
+  orbWrite.QPpertEnergies() = QPpertEnergiesTest;
+  orbWrite.QPdiag().eigenvalues() = QPdiagEnergiesTest;
+  orbWrite.QPdiag().eigenvectors() = QPdiagCoefficientsTest;
+  orbWrite.BSESinglets().eigenvalues() = BSESingletEnergiesTest;
+  orbWrite.BSESinglets().eigenvectors() = BSESingletCoefficientsTest;
+  orbWrite.BSESinglets().eigenvectors2() = BSESingletCoefficientsARTest;
+  orbWrite.BSETriplets().eigenvalues() = BSETripletEnergiesTest;
+  orbWrite.BSETriplets().eigenvectors() = BSETripletCoefficientsTest;
+
+  orbWrite.WriteToCpt("xtp_testing.hdf5");
 
   // Read Orbitals
   Orbitals orbRead;
@@ -161,6 +159,23 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
     BOOST_CHECK_EQUAL(atomRead.getNuccharge(), atomTest.getNuccharge());
     BOOST_CHECK_EQUAL(atomRead.getElement(), atomTest.getElement());
   }
+
+  // Check if basissets are equal after a write read cycle
+  std::stringstream ssWrite;
+  ssWrite << orbWrite.getDftBasis();
+  std::stringstream ssRead;
+  ssRead << orbRead.getDftBasis();
+
+  bool basissets_equal = (ssWrite.str() == ssRead.str());
+  BOOST_CHECK(basissets_equal);
+
+  if(!basissets_equal){
+    std::cout << "Thing we wrote:" << std::endl;
+    std::cout << ssWrite.str();
+    std::cout << "Thing we read:" << std::endl;
+    std::cout << ssRead.str();
+  }
+  
   libint2::finalize();
 }
 


### PR DESCRIPTION
This fixes a bug in the basisset serialization that messed up the Vxc part of the GW calculation. 

@junghans this is a pretty serious bug and it would be great if we can get this change in before the new release