### PR TITLE
cmake: remove PYTHON_INSTDIR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 2022-rc.2 (released XX.11.21)
 -  use python3 in xtp-tutorials (#917)
 -  bump required boost version to 1.71 (#915, #916)
 -  clean up NOTICE files (#919)
+-  rm PYTHON_INSTDIR from VOTCARC (#924)
 
 Version 2022-rc.1 (released 26.11.21)
 =====================================

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -67,14 +67,6 @@ if(VOTCA_SPHINX_DIR)
   add_custom_target(doc-tools)
 endif()
 
-if(Python_EXECUTABLE AND NOT PYTHON_INSTDIR)
-  execute_process(
-    COMMAND
-      ${Python_EXECUTABLE} -c
-      "import distutils.sysconfig as cg; print(cg.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True, standard_lib=False))"
-    OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif(Python_EXECUTABLE AND NOT PYTHON_INSTDIR)
-
 ########################################################################
 # Checks what linear algebra packages are installed                    #
 ########################################################################

--- a/tools/scripts/VOTCARC.bash.in
+++ b/tools/scripts/VOTCARC.bash.in
@@ -25,11 +25,6 @@ VOTCASHARE="@CMAKE_INSTALL_FULL_DATADIR@/votca"
 
 export PATH MANPATH @LD_LIBRARY_PATH@ VOTCASHARE
 
-if [ -n "@PYTHON_INSTDIR@" ]; then
-  PYTHONPATH="@PYTHON_INSTDIR@${PYTHONPATH:+:}${PYTHONPATH}"
-  export PYTHONPATH
-fi
-
 #bash completion
 if [ -n "$BASH_VERSION" ]; then 
   for comp in "${VOTCASHARE}"/rc/*completion.bash; do


### PR DESCRIPTION
Originally added in votca/tools#340 for votca/xtp#673 (replaced #842 then #749)

Triggers a warning on python 3.10:
```
<string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
<string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
```

So if #749 ever gets close to being merged this needs to reverted (or added back to #749).