### PR TITLE
Revert "CI: ubuntu:latest is broken"

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   CI:
     # Ubuntu devel, Fedora Rawhide and some other in the matrix are allowed to fail, so continue with other builds
-    continue-on-error: ${{ matrix.distro == 'ubuntu:devel' || matrix.distro == 'opensuse:latest' || matrix.distro == 'fedora:rawhide' || matrix.continue-on-error == true || matrix.distro == 'ubuntu:latest' }}
+    continue-on-error: ${{ matrix.distro == 'ubuntu:devel' || matrix.distro == 'opensuse:latest' || matrix.distro == 'fedora:rawhide' || matrix.continue-on-error == true }}
     strategy:
       matrix:
         distro: ['fedora:latest', 'fedora:rawhide', 'opensuse:latest', 'ubuntu:latest', 'ubuntu:devel', 'ubuntu:rolling', 'fedora:intel']

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Version 2022 (released XX.12.21)
 
 -  fix some icpc warnings (#934)
 -  only check for pytest if testing is enabled (#930)
--  exclude some builds from CI (#940, #942)
+-  exclude some builds from CI (#940, #942, #944)
 -  update interface documentation (#939)
 -  update install guide for binary packages (#936)
 -  fixed sigma plot options passing (#943)


### PR DESCRIPTION
This reverts commit 70fd8f7ec4bcd7b302ab323aacd9183dc4011891 and
a60df23d6207351e7d3b47eb94c8a887ba921823 and hence parts of #940.

We can do this revert as #941 was fixed via https://github.com/votca/buildenv/pull/174.