### PR TITLE
csg_resample will now generate an evenly spaced grid by scaling step [stable]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version 2022.1 (released XX.01.22)
 ==================================
 
 -  fix PROJECT_VERSION in subdirs (#951) 
+-  make csg_resample and csg_stat spacing consistent (#956)
 
 Version 2022 (released 15.01.22)
 ================================

--- a/tools/src/libtools/table.cc
+++ b/tools/src/libtools/table.cc
@@ -180,11 +180,12 @@ istream &operator>>(istream &in, Table &t) {
 void Table::GenerateGridSpacing(double min, double max, double spacing) {
   Index vec_size = (Index)((max - min) / spacing + 1.00000001);
   resize(vec_size);
-  int i;
+  // adjust spacing to generate evenly distributed bins till max
+  double spacing_scaled = (max - min) / (double(vec_size) - 1.0);
 
   double r_init;
-
-  for (r_init = min, i = 0; i < vec_size - 1; r_init += spacing) {
+  int i;
+  for (r_init = min, i = 0; i < vec_size - 1; r_init += spacing_scaled) {
     x_[i++] = r_init;
   }
   x_[i] = max;


### PR DESCRIPTION
Replacement for #955

Fix #955
Fix #954 