### PR TITLE
made awk ignore locale if it is not an English one so that it always uses a period as a decimal separator instead of a comma

### DIFF
--- a/csg/share/scripts/inverse/calc_pressure_lammps.sh
+++ b/csg/share/scripts/inverse/calc_pressure_lammps.sh
@@ -33,5 +33,5 @@ p_file="$(csg_get_property cg.inverse.lammps.pressure_file)"
 
 [[ -f ${p_file} ]] || die "${0##*/}: pressure file '${p_file}' doesn't exist" 
 
-p_now=$(awk 'NR > 1 {avg += $1} END {printf "%.16f\n", avg/(NR-1)}' ${p_file}) || die "${0##*/}: pressure averaging failed" 
+p_now=$(LC_ALL=C awk 'NR > 1 {avg += $1} END {printf "%.16f\n", avg/(NR-1)}' ${p_file}) || die "${0##*/}: pressure averaging failed" 
 echo "Pressure=${p_now}" > "$1"

--- a/csg/share/scripts/inverse/functions_common.sh
+++ b/csg/share/scripts/inverse/functions_common.sh
@@ -442,7 +442,7 @@ is_num() { #checks if all arguments are numbers
   local i res
   [[ -z $1 ]] && die "${FUNCNAME[0]}: Missing argument"
   for i in "$@"; do
-    res=$(awk -v x="$i" 'BEGIN{ print ( x+0==x ) }') || die "${FUNCNAME[0]}: awk failed"
+    res=$(LC_ALL=C awk -v x="$i" 'BEGIN{ print ( x+0==x ) }') || die "${FUNCNAME[0]}: awk failed"
     [[ $res -eq 1 ]] || return 1
     unset res
   done
@@ -730,10 +730,10 @@ csg_calc() { #simple calculator, a + b, ...
   #we use awk -v because then " 1 " or "1\n" is equal to 1
   case "$2" in
     "+"|"-"|'*'|"/"|"^")
-       res="$(awk -v x="$1" -v y="$3" "BEGIN{print ( x $2 y ) }")" || die "${FUNCNAME[0]}: awk -v x='$1' -v y='$3' 'BEGIN{print ( x $2 y ) }' failed"
+       res="$(LC_ALL=C awk -v x="$1" -v y="$3" "BEGIN{print ( x $2 y ) }")" || die "${FUNCNAME[0]}: awk -v x='$1' -v y='$3' 'BEGIN{print ( x $2 y ) }' failed"
        true;;
     '>'|'<' )
-       res="$(awk -v x="$1" -v y="$3" "BEGIN{print ( x $2 y )}")" || die "${FUNCNAME[0]}: awk -v x='$1' -v y='$3' 'BEGIN{print ( x $2 y )}' failed"
+       res="$(LC_ALL=C awk -v x="$1" -v y="$3" "BEGIN{print ( x $2 y )}")" || die "${FUNCNAME[0]}: awk -v x='$1' -v y='$3' 'BEGIN{print ( x $2 y )}' failed"
        #awk return 1 for true and 0 for false, shell exit codes are the other way around
        ret="$((1-$res))"
        #return value matters
@@ -741,7 +741,7 @@ csg_calc() { #simple calculator, a + b, ...
        true;;
     "="|"==")
        #this is really tricky... case x=0,y=0 is catched by (x==y) after that |x-y|/max(|x|,|y|) will work expect for x,y beginng close to zero
-       res="$(awk -v x="$1" -v y="$3" -v e="$err" \
+       res="$(LC_ALL=C awk -v x="$1" -v y="$3" -v e="$err" \
        'function max(x,y){return (x>y)?x:y;} function abs(x){return (x<0)?-x:x;} BEGIN{if (x==y){print 1;}else{if (abs(x-y)<e){print 1;}else{ print ( abs(x-y)/max(abs(x),abs(y)) < e );}}}')" \
 	 || die "${FUNCNAME[0]}: awk for =/== failed"
        #awk return 1 for true and 0 for false, shell exit codes are the other way around

--- a/csg/share/scripts/inverse/optimizer_target_pressure.sh
+++ b/csg/share/scripts/inverse/optimizer_target_pressure.sh
@@ -42,5 +42,5 @@ fi
 
 p_target="$(csg_get_interaction_property inverse.p_target)"
 
-critical awk -v x="$p_now" -v y="$p_target" 'BEGIN{print sqrt((x-y)^2)}' > "${name}.pressure.conv"
+critical LC_ALL=C awk -v x="$p_now" -v y="$p_target" 'BEGIN{print sqrt((x-y)^2)}' > "${name}.pressure.conv"
 

--- a/csg/share/scripts/inverse/postupd_splinesmooth.sh
+++ b/csg/share/scripts/inverse/postupd_splinesmooth.sh
@@ -37,8 +37,8 @@ step=$(csg_get_interaction_property step)
 tmpfile=$(critical mktemp ${name}.XXX)
 
 sed -e '/^#/d' "$1" | sed -n -e '/i[[:space:]]*$/p' > $tmpfile
-spmin=$(sed -n -e '1p' $tmpfile | awk '{print $1}')
-spmax=$(sed -n -e '$p' $tmpfile | awk '{print $1}')
+spmin=$(sed -n -e '1p' $tmpfile | LC_ALL=C awk '{print $1}')
+spmax=$(sed -n -e '$p' $tmpfile | LC_ALL=C awk '{print $1}')
 spstep=$(csg_get_interaction_property inverse.post_update_options.splinesmooth.step)
 
 comment="$(get_table_comment)"


### PR DESCRIPTION
A quick fix for the issue https://github.com/votca/votca/issues/998
made awk ignore locale if it is not an English one so that it always uses . as a decimal separator instead of ,