### PR TITLE
functions_common.sh: fix LC_ALL to C

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Version 2022.1 (released XX.01.22)
 -  fix CI build on Ubuntu (#981)
 -  fix CI builds with icpx (#984)
 -  fix CI builds with ESPResSo 4.2.0 (#993)
+-  fix localization issue (#998, #1000)
 
 Version 2022 (released 15.01.22)
 ================================

--- a/csg/share/scripts/inverse/functions_common.sh
+++ b/csg/share/scripts/inverse/functions_common.sh
@@ -29,6 +29,10 @@ echo
 exit 0
 fi
 
+# avoid localization of numbers, i.e. 1,0 instead 1.0 e.g. by awk in csg_calc
+# see votca/votca#998
+export LC_ALL=C
+
 export BASH #need in CsgFunctions.pm
 
 shopt -s extglob


### PR DESCRIPTION
Fix #998 

Slightly better than #999 (I think)