### PR TITLE
Reduce warnings XML options not set in pyxtp 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ For more detailed information about the changes see the history of the
 Version 2023-rc.2-dev
 =====================
 
+-  fix pyxtp option restart (#1074)
 -  fix Changelog check (#1070)
 -  add python bindings for xtp (#1061)
 

--- a/xtp/src/pyxtp/pyxtp/options.py
+++ b/xtp/src/pyxtp/pyxtp/options.py
@@ -58,13 +58,13 @@ class Options:
         options = self._opts.to_flat_dict()
 
         # update the options from the user provided input
-        self._xml_tree = update_xml_text(self._xml_tree, options)
+        xml_tree_cpy = update_xml_text(self._xml_tree, options)
 
         # remove the empty elements
-        self._xml_tree = remove_empty_text_elements(self._xml_tree)
+        xml_tree_cpy = remove_empty_text_elements(xml_tree_cpy)
 
         # write the file
-        self._xml_tree.write(filename)
+        xml_tree_cpy.write(filename)
 
 
 class _Opts_t:

--- a/xtp/src/pyxtp/pyxtp/xml_editor.py
+++ b/xtp/src/pyxtp/pyxtp/xml_editor.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import os
 from lxml import etree
 from lxml.etree import Element, ElementTree
-from copy import deepcopy 
+from copy import deepcopy
 
 def update_xml_text(xml: ElementTree, dict_options: dict) -> ElementTree:
     """update default option files with the user define options

--- a/xtp/src/pyxtp/pyxtp/xml_editor.py
+++ b/xtp/src/pyxtp/pyxtp/xml_editor.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import os
 from lxml import etree
 from lxml.etree import Element, ElementTree
-
+from copy import deepcopy 
 
 def update_xml_text(xml: ElementTree, dict_options: dict) -> ElementTree:
     """update default option files with the user define options
@@ -17,14 +17,17 @@ def update_xml_text(xml: ElementTree, dict_options: dict) -> ElementTree:
         ET.ElementTree: xml structure containing the update options.
     """
 
+    # copy the xml tree
+    xml_cpy = deepcopy(xml)
+
     # replace text value of the dict elements
     for key, value in dict_options.items():
         try:
-            xml.find('.//'+key).text = str(value)
+            xml_cpy.find('.//'+key).text = str(value)
         except Exception as e:
             print(e)
             print(key, ' not found ')
-    return xml
+    return xml_cpy
 
 
 def insert_linked_xmlfiles(tree: ElementTree, base_path: str) -> None:


### PR DESCRIPTION
This small PR fixes the log issue raised in #1072 
The xml tree representing the option is now first copied internally instead of modified inplace before being written to file. This reduces the log file in case two calculations are performed once after the other using the same calculator instance (e.g. for a force calculation). 