### PR TITLE
CI: run Intel build on Ubuntu

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   CI:
     # Ubuntu devel, Fedora Rawhide and some other in the matrix are allowed to fail, so continue with other builds
-    continue-on-error: ${{ matrix.distro == 'ubuntu:devel' || matrix.distro == 'opensuse:latest' || matrix.distro == 'fedora:rawhide' || matrix.distro == 'fedora:intel' || matrix.continue-on-error == true }}
+    continue-on-error: ${{ matrix.distro == 'ubuntu:devel' || matrix.distro == 'opensuse:latest' || matrix.distro == 'fedora:rawhide' || matrix.distro == 'ubuntu:intel' || matrix.continue-on-error == true }}
     strategy:
       matrix:
-        distro: ['fedora:latest', 'fedora:rawhide', 'opensuse:latest', 'ubuntu:latest', 'ubuntu:devel', 'ubuntu:rolling', 'fedora:intel']
+        distro: ['fedora:latest', 'fedora:rawhide', 'opensuse:latest', 'ubuntu:latest', 'ubuntu:devel', 'ubuntu:rolling', 'ubuntu:intel']
         toolchain: [gnu, clang]
         cmake_build_type: [Release, Debug]
         minimal: [false]
@@ -47,10 +47,10 @@ jobs:
             toolchain: gnu
             cmake_build_type: Release
             own_gmx: true
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             toolchain: intel-oneapi
             cmake_build_type: Release
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             toolchain: intel-oneapi
             cmake_build_type: Debug
           - distro: 'fedora:gmx2019'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Version 2024-dev
 -  fixed dftcoupling option path (#1107)
 -  cmake: fix MKL detection (#1110)
 -  cmake: handover GMX options transparently (#1108)
+-  CI: Switch Intel build to Ubuntu (#1111)
 
 Version 2024 (released 22.01.24)
 ================================


### PR DESCRIPTION
The intel package cannot be installed on Fedora 39+ anymore, and F38 will end of life in June, so let's try to switch to Ubuntu for the Intel builds.