### PR TITLE
CI: fix rawhide and opensuse warnings

### DIFF
--- a/.github/actions/setup/setup.sh
+++ b/.github/actions/setup/setup.sh
@@ -105,7 +105,7 @@ if [[ ${INPUT_DISTRO} = ubuntu:* && ${INPUT_TOOLCHAIN} = "gnu" ]]; then
 fi
 if [[ ( ${INPUT_DISTRO} = "opensuse:latest" || ${INPUT_DISTRO} = "fedora:rawhide" ) && ${INPUT_TOOLCHAIN} = "clang" ]]; then
   # workaround for votca/votca#1119, libint2 warning on clang, deprecated-declarations
-  cmake_args+=( "-DVOTCA_EXTRA_WARNING_FLAGS=\"-Wno-deprecated-declarations" )
+  cmake_args+=( "-DVOTCA_EXTRA_WARNING_FLAGS=\"-Wno-deprecated-declarations\"" )
 fi
 
 if [[ ${INPUT_CODE_ANALYZER} = "codeql" ]]; then

--- a/.github/actions/setup/setup.sh
+++ b/.github/actions/setup/setup.sh
@@ -103,6 +103,10 @@ if [[ ${INPUT_DISTRO} = ubuntu:* && ${INPUT_TOOLCHAIN} = "gnu" ]]; then
   # workaround for votca/votca#1080, libint2 warning, misleading-indentation
   cmake_args+=( "-DVOTCA_EXTRA_WARNING_FLAGS=\"-Wno-deprecated-copy -Wno-misleading-indentation -Wno-maybe-uninitialized -Wno-array-bounds -Wno-stringop-overflow\"" )
 fi
+if [[ ( ${INPUT_DISTRO} = "opensuse:latest" || ${INPUT_DISTRO} = "fedora:rawhide" ) && ${INPUT_TOOLCHAIN} = "clang" ]]; then
+  # workaround for votca/votca#1119, libint2 warning on clang, deprecated-declarations
+  cmake_args+=( "-DVOTCA_EXTRA_WARNING_FLAGS=\"-Wno-deprecated-declarations" )
+fi
 
 if [[ ${INPUT_CODE_ANALYZER} = "codeql" ]]; then
   # CodeQL does not work with valgrind

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Version 2024-dev
 -  CI: Switch Intel build to Ubuntu (#1111)
 -  CI: update GitHub actions (#1112)
 -  Fix Python print in hoomd tutorial (#1118)
+-  CI: fix rawhide and opensuse warnings (#1119)
 
 Version 2024 (released 22.01.24)
 ================================


### PR DESCRIPTION
```
2024-03-29T05:20:36.1465244Z In file included from /__w/votca/votca/xtp/src/libxtp/aomatrices/aoecp.cc:27:
2024-03-29T05:20:36.1468514Z /usr/include/libint2/solidharmonics.h:218:45: error: 'iterator<std::input_iterator_tag, libint2::solidharmonics::SolidHarmonicsCoefficients<double>>' is deprecated [-Werror,-Wdeprecated-declarations]
2024-03-29T05:20:36.1471909Z   218 |         struct CtorHelperIter : public std::iterator<std::input_iterator_tag, SolidHarmonicsCoefficients> {
2024-03-29T05:20:36.1473369Z       |       
```