### PR TITLE
Fix build with Boost 1.85.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Version 2024-dev
 -  Fix Python print in hoomd tutorial (#1118)
 -  CI: fix rawhide, ubuntu and opensuse warnings (#1119, #1122)
 -  votca_help2doc: fix python warnings (#1121)
+-  Fix build with boost-1.85.0 (#1123)
 
 Version 2024 (released 22.01.24)
 ================================

--- a/csg/src/libcsg/modules/io/pdbreader.cc
+++ b/csg/src/libcsg/modules/io/pdbreader.cc
@@ -22,7 +22,6 @@
 
 // Third party includes
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/lexical_cast.hpp>
 
 // VOTCA includes

--- a/xtp/src/libxtp/calculators/kmcmultiple.cc
+++ b/xtp/src/libxtp/calculators/kmcmultiple.cc
@@ -20,6 +20,7 @@
 
 // Third party includes
 #include <boost/format.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 // VOTCA includes
 #include <votca/tools/constants.h>


### PR DESCRIPTION
Build was failing with Boost 1.85.0:
```
/tmp/votca-20240425-65266-25g6le/csg/src/libcsg/modules/io/pdbreader.cc:25:10: fatal error: 'boost/filesystem/convenience.hpp' file not found
#include <boost/filesystem/convenience.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
/tmp/votca-20240425-70011-caqdam/xtp/src/libxtp/calculators/kmcmultiple.cc:211:28: error: no template named 'numeric_cast' in namespace 'boost'; did you mean 'Eigen::internal::numeric_list'?
  unsigned long maxsteps = boost::numeric_cast<unsigned long>(runtime_);
                           ^~~~~~~~~~~~~~~~~~~
                           Eigen::internal::numeric_list
```

First error is due to `convenience.hpp` removal - https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html. I didn't see any usage of `boost::filesystem` that would require this so just removed header as recommended.

Second error is probably some indirect include being removed. Added missing header. Should work for all supported Boost (I see Votca's minimum is 1.71.0, which has header https://www.boost.org/doc/libs/1_71_0/boost/numeric/conversion/cast.hpp)

---

Seen while updating Boost in Homebrew - https://github.com/Homebrew/homebrew-core/pull/169237