### PR TITLE
cmake: clean up hdf5 detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Version 2024-dev
 -  votca_help2doc: fix python warnings (#1121)
 -  Fix build with boost-1.85.0 (#1123)
 -  make some interpreters explicit  (#1125)
+-  cmake: update hdf5 detection for cmake hdf5 (#1126)
 
 Version 2024 (released 22.01.24)
 ================================

--- a/xtp/CMakeLists.txt
+++ b/xtp/CMakeLists.txt
@@ -17,12 +17,8 @@ find_package(ecpint REQUIRED)
 set_package_properties(ecpint PROPERTIES TYPE REQUIRED PURPOSE "Calculates Gaussian integrals over pseudo potentials")
 message(STATUS "Found libecpint: ${ecpint_DIR}")
 
-find_package(HDF5 1.8 REQUIRED COMPONENTS CXX)
+find_package(HDF5 1.8 COMPONENTS CXX)
 set_package_properties(HDF5 PROPERTIES TYPE REQUIRED PURPOSE "Used to read/write HDF5 data files")
-
-if(HDF5_VERSION VERSION_GREATER 1.8)
-  message(WARNING "HDF5 will be used such that it is compatible with version 1.8.")
-endif()
 
 # https://github.com/votca/xtp/issues/436, hdf5-1.10.4 generates a implicitly-declared operator warning
 if(HDF5_VERSION VERSION_GREATER_EQUAL 1.10.4 AND HDF5_VERSION VERSION_LESS_EQUAL 1.10.6)


### PR DESCRIPTION
If hdf5 is build with cmake, v1.12 doesn't satisfy the version requirement of v1.8 anymore as it counts it as incompatible, we let's drop version requirement in our cmake.

Related to #1124 