### PR TITLE
removing additonal space in csg_table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Version 2024-dev
 -  add CI on FreeBSD (#1124)
 -  Fix Sphinx build (#1131)
 -  add CONTRIBUTING.md (#1133)
+-  csg_table fix (#1134)
 
 Version 2024 (released 22.01.24)
 ================================

--- a/csg/share/scripts/inverse/csg_table
+++ b/csg/share/scripts/inverse/csg_table
@@ -129,7 +129,7 @@ update imc_single update_imc_single.sh
 optimizer prepare_state optimizer_prepare_state.sh
 optimizer parameters_to_potential optimizer_parameters_to_potential.sh
 optimizer state_to_potentials optimizer_state_to_potentials.sh
-optimizer state_to_mapping  optimizer_state_to_mapping.sh
+optimizer state_to_mapping optimizer_state_to_mapping.sh
 update optimizer update_optimizer.sh
 update optimizer_single update_optimizer_single.sh
 


### PR DESCRIPTION
Having that additional space causes problems in `functions_common.sh` on some architectures.