### PR TITLE
Move pyxtp to a python3 package

### DIFF
--- a/xtp-tutorials/pyxtp/scripts/run_mapchecker.py
+++ b/xtp-tutorials/pyxtp/scripts/run_mapchecker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Examples to show xtp_binds usage."""
-from pyxtp import xtp_binds
+from pyxtp_binds import xtp_binds
 from pathlib import Path
 from multiprocessing import cpu_count
 

--- a/xtp/src/pyxtp/CMakeLists.txt
+++ b/xtp/src/pyxtp/CMakeLists.txt
@@ -1,19 +1,9 @@
-find_package(Python 3.5 COMPONENTS Development)
+find_package(Python 3.5 COMPONENTS Development Interpreter)
 set_package_properties(Python PROPERTIES TYPE RECOMMENDED PURPOSE "Used to build xtp python bindings")
 find_package(pybind11)
 set_package_properties(pybind11 PROPERTIES TYPE RECOMMENDED PURPOSE "Used to build xtp python bindings")
 
-foreach(_pkg ase xmltodict pytest)
-  if(NOT PY${_pkg}_FOUND)
-    execute_process(COMMAND ${Python_EXECUTABLE} -c "import ${_pkg}" RESULT_VARIABLE IMPORT_py${_pkg})
-    if(IMPORT_py${_pkg} EQUAL 0)
-      set(PY${_pkg}_FOUND TRUE CACHE INTERNAL "")
-      message(STATUS "Found python module ${_pkg}")
-    endif()
-  endif()
-endforeach()
-
-if(NOT pybind11_FOUND OR NOT Python_Development_FOUND OR NOT PYase_FOUND OR NOT PYxmltodict_FOUND)
+if(NOT pybind11_FOUND OR NOT Python_Development_FOUND OR NOT Python_Interpreter_FOUND)
   message(STATUS "Skipping xtp python bindings")
   return()
 endif()
@@ -28,26 +18,24 @@ set_target_properties(xtp_binds PROPERTIES XTP_PYPATH "${XTP_PYPATH}")
 target_link_libraries(xtp_binds PUBLIC VOTCA::votca_xtp)
 
 if(NOT CMAKE_INSTALL_PYTHON_LIBDIR)
-  set(CMAKE_INSTALL_PYTHON_LIBDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  set(CMAKE_INSTALL_PYTHON_LIBDIR ${Python_SITELIB})
 endif()
-install(TARGETS xtp_binds LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHON_LIBDIR}/pyxtp)
-add_library(VOTCA::xtp_binds ALIAS xtp_binds)
 
-file(GLOB_RECURSE PYXTP_FILES pyxtp/*.py)
-message(STATUS "PYTHON INSTALL: ${CMAKE_INSTALL_PYTHON_LIBDIR}")
-install(FILES ${PYXTP_FILES} DESTINATION ${CMAKE_INSTALL_PYTHON_LIBDIR}/pyxtp)
+install(TARGETS xtp_binds LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHON_LIBDIR}/pyxtp_binds)
 
-# copy py files to build dir, so CMAKE_CURRENT_BINARY_DIR is a complete py module with script and xtp_binds
-foreach(_PYFILE ${PYXTP_FILES})
-  get_filename_component(_FILE "${_PYFILE}" NAME)
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_FILE}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_PYFILE} ${CMAKE_CURRENT_BINARY_DIR}/${_FILE}
-    DEPENDS ${_DEP}
+install (CODE "
+    message(STATUS \"Installing Python package with pip from ${CMAKE_CURRENT_SOURCE_DIR}...\")
+    message(STATUS \"${Python_EXECUTABLE} -m pip install ${CMAKE_CURRENT_SOURCE_DIR}\")
+    execute_process(
+    COMMAND ${Python_EXECUTABLE} -m pip install ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE _pip_result
   )
-  list(APPEND BINARY_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/${_FILE})
-endforeach()
-add_custom_target(xtp_binary_scripts DEPENDS ${BINARY_SCRIPTS})
-add_dependencies(xtp_binds xtp_binary_scripts)
+  if(NOT _pip_result EQUAL 0)
+    message(FATAL_ERROR \"pip install failed with code \${_pip_result}\")
+  endif()"
+)
+
+add_library(VOTCA::xtp_binds ALIAS xtp_binds)
 
 if(BUILD_TESTING AND PYpytest_FOUND)
   add_test(NAME integration_test_xtp_binds COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR} )

--- a/xtp/src/pyxtp/pyproject.toml
+++ b/xtp/src/pyxtp/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyxtp"
+version = "0.1.0"
+authors = [
+  { name="Bjoern Baumeier", email="bjoernbaumeier@gmail.com" },
+]
+
+dependencies = ["ase", "xmltodict", "h5py", "lxml", "rdkit"]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+
+[project.urls]
+Homepage = "https://github.com/votca/votca"
+Issues = "https://github.com/votca/votca/issues"

--- a/xtp/src/pyxtp/pyxtp/xtp.py
+++ b/xtp/src/pyxtp/pyxtp/xtp.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ase import Atoms
 from ase.calculators.calculator import Calculator, equal, PropertyNotImplementedError
 from .capture_standard_output import capture_standard_output
-from pyxtp import xtp_binds
+from pyxtp_binds import xtp_binds
 from .options import Options
 from .utils import BOHR2ANG
 


### PR DESCRIPTION
This commit changes how pyxtp is built and installed such that it uses the standard python3 packaging system. It does so with the two following steps:

1. Seperate the pybind11 bindings into their own python module
2. All pyxtp modules and scripts are installed by pip

Fixes #1179