### PR TITLE
cmake: add -Wno-c2y-extensions for clang on rawhide

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Version 2025.1-dev
 -  add integration tests for xtp (#1220)
 -  CI: docker build add provenance=false (#1225)
 -  unbuffered KMC output on single thread (#1226)
+-  CI: ignore c2y-extensions warning on rawhide (#1228)
 
 Version 2025.1 (released 03.10.25)
 ==================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ if(ENABLE_WARNING_FLAGS)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-conversion")
   endif()
+  # ignore c2y-extentions warnings on newer clang, this is mostly in boost
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=c2y-extensions")
+  endif()
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel") #only icpc, not icpx
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcheck -Wno-sign-conversion")
   endif()


### PR DESCRIPTION
Fix #1227 