### PR TITLE
fixing QP_solve bisection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 2026-dev
 -  Add DFT/GW-BSE Tight-Binding Hamiltonian calculator (#1238)
 -  fix xtp_binds test timeout (#1239, #1240)
 -  use IEEE data types in HDF5 (#1241, #1242)
+-  fixing bisection in QP solve (#1244)
 
 Version 2026 (released 09.03.26)
 ================================

--- a/xtp/include/votca/xtp/qp_solver_utils.h
+++ b/xtp/include/votca/xtp/qp_solver_utils.h
@@ -383,11 +383,11 @@ boost::optional<RootCandidate> RefineQPInterval(
       return boost::none;
     }
   } else {
-    cand.omega =
-        use_brent ? SolveQP_Brent(lowerbound, f_lowerbound, upperbound,
-                                   f_upperbound, f, opt)
-                  : SolveQP_Bisection(lowerbound, f_lowerbound, upperbound,
-                                      f_upperbound, f, opt);
+    cand.omega = use_brent
+                     ? SolveQP_Brent(lowerbound, f_lowerbound, upperbound,
+                                     f_upperbound, f, opt)
+                     : SolveQP_Bisection(lowerbound, f_lowerbound, upperbound,
+                                         f_upperbound, f, opt);
   }
 
   cand.residual = f.value(cand.omega, EvalStage::Refine);

--- a/xtp/include/votca/xtp/qp_solver_utils.h
+++ b/xtp/include/votca/xtp/qp_solver_utils.h
@@ -362,10 +362,33 @@ boost::optional<RootCandidate> RefineQPInterval(
     const SolverOptions& opt, bool use_brent) {
   RootCandidate cand;
 
-  cand.omega = use_brent ? SolveQP_Brent(lowerbound, f_lowerbound, upperbound,
-                                         f_upperbound, f, opt)
-                         : SolveQP_Bisection(lowerbound, f_lowerbound,
-                                             upperbound, f_upperbound, f, opt);
+  // Near-exact-zero brackets: one endpoint is already essentially at the root.
+  // Bisection and Brent both require opposite signs; handle this case directly
+  // by returning whichever endpoint is closer to zero. This occurs when the
+  // local mini-scan inside refine_and_store finds a near-zero node and inserts
+  // a same-sign bracket -- those brackets are valid root indicators but cannot
+  // be refined by interval methods.
+  const bool left_near_zero = std::abs(f_lowerbound) <= opt.g_sc_limit;
+  const bool right_near_zero = std::abs(f_upperbound) <= opt.g_sc_limit;
+  const bool same_sign = (f_lowerbound * f_upperbound > 0.0);
+
+  if (same_sign) {
+    if (left_near_zero || right_near_zero) {
+      // Pick the endpoint closest to zero as the root estimate
+      cand.omega = (std::abs(f_lowerbound) <= std::abs(f_upperbound))
+                       ? lowerbound
+                       : upperbound;
+    } else {
+      // No bracket and no near-zero endpoint -- cannot refine, skip silently
+      return boost::none;
+    }
+  } else {
+    cand.omega =
+        use_brent ? SolveQP_Brent(lowerbound, f_lowerbound, upperbound,
+                                   f_upperbound, f, opt)
+                  : SolveQP_Bisection(lowerbound, f_lowerbound, upperbound,
+                                      f_upperbound, f, opt);
+  }
 
   cand.residual = f.value(cand.omega, EvalStage::Refine);
   cand.deriv = f.deriv(cand.omega);


### PR DESCRIPTION
**Fix: QP solver crash when near-zero bracket endpoints violate bisection sign condition**

**Problem**

The adaptive QP grid search in `SolveQP_Grid_Windowed` performs a local mini-scan inside each coarse sign-change interval. This mini-scan inserts brackets into `local_brackets` under three conditions: a genuine sign change, a near-zero left node, or a near-zero right node. The two near-zero cases do not guarantee opposite signs at the bracket endpoints. When such a same-sign bracket was selected as the best candidate and passed to `RefineQPInterval`, `SolveQP_Bisection` immediately threw:

```
std::runtime_error: Bisection needs a positive and negative function value
```

causing `std::terminate` via an uncaught exception in the OpenMP parallel region.

**Fix**

Guard `RefineQPInterval` against same-sign input before dispatching to bisection or Brent. Three cases are now handled:

- **Opposite signs**: unchanged — bisection or Brent proceeds as before
- **Same sign, one endpoint within `g_sc_limit` of zero**: that endpoint is itself a valid root; return it directly without interval refinement
- **Same sign, neither endpoint near zero**: return `boost::none` silently, allowing the outer search to fall through to linearisation

`RefineQPInterval` is the correct location for this guard since it is the single entry point for all interval refinement and defends all call sites uniformly.

**Impact**

Fixes a crash seen on systems where `Sigma_c(omega)` passes very close to a root at a mini-scan grid point, which can occur with certain DFT starting points or basis sets (observed on CO and tetracene monomers). No behavioural change for the common case of well-bracketed sign changes.